### PR TITLE
Fix: Change pypi-publish action from master to release/v1.13

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,7 @@ jobs:
     - name: upload distribution package
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ github.event.repository.name }} - ${{ github.ref_name}}
+        name: ${{ github.event.repository.name }}-${{ github.ref_name }}
         path: dist/
 
   publish-to-testpypi:
@@ -45,7 +45,7 @@ jobs:
     - name: download distribution package
       uses: actions/download-artifact@v4
       with:
-        name: ${{ github.event.repository.name }}
+        name: ${{ github.event.repository.name }}-${{ github.ref_name }}
         path: dist/
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1.13
@@ -64,7 +64,7 @@ jobs:
     - name: download distribution package
       uses: actions/download-artifact@v4
       with:
-        name: ${{ github.event.repository.name }} - ${{ github.ref_name}}
+        name: ${{ github.event.repository.name }}-${{ github.ref_name }}
         path: dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1.13


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
`pypa/gh-action-pypi-publish@master` has been sunset, which causes the workflow that publishes to PyPi to fail. This PR changes the action that publishes to PyPi in `pypi-publish.yml` from `pypa/gh-action-pypi-publish@master` to `pypa/gh-action-pypi-publish@release/v1.13`. It also removes the matrix strategy since the build has been tested with different pythons versions in `python-package.yml` and to avoid publishing the same version to PyPi multiple times.

<!-- Add any linked issue(s) -->
**Fixes**
Change the action that publishes to PyPi in `pypi-publish.yml` from `pypa/gh-action-pypi-publish@master` to `pypa/gh-action-pypi-publish@release/v1.13`. 

*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->
Not applicable

*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->