### PR TITLE
Release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [v0.6.0](https://github.com/UAL-RE/redata-commons/tree/v0.6.0) (2025-11-06)
+## [v0.6.0](https://github.com/UAL-RE/redata-commons/tree/v0.6.0) (2025-11-17)
 
 ## What's Changed
 * Update RTD for pypi by @yhan818 in https://github.com/UAL-RE/redata-commons/pull/31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix: Use platform.uname instead of os.uname (Issue #37) by @zoidy in https://github.com/UAL-RE/redata-commons/pull/38
 * Chore: Add issue templates and update PR templates by @HafeezOJ in https://github.com/UAL-RE/redata-commons/pull/44
 * Update redata-commons dependencies by @HafeezOJ in https://github.com/UAL-RE/redata-commons/pull/42
+* Fix: Change pypi-publish action from master to release/v1.13 by @HafeezOJ in https://github.com/UAL-RE/redata-commons/pull/48
 
 
 ## [v0.5.0](https://github.com/UAL-RE/redata-commons/tree/v0.5.0) (2022-07-01)


### PR DESCRIPTION
**Description**
<!-- Do not push the release tag until this PR is merged -->
This pull request updates redata-commons `v0.5.0` -> `v0.6.0`. It re-releases v0.6.0 due to failed publish to PyPI workflow for the initial release caused by a sunset master branch of GitHub [publish to pypi action](https://github.com/marketplace/actions/pypi-publish#-master-branch-sunset-).

**Check**

<!-- After using this template, check the links in the PR to ensure they resolve and replace `../../` with `../tree/main/` in any broken link. -->
- [x] Title and description have been updated.
- [x] Verified the correct branch is being merged by checking the text immediately below the PR title.
- [x] Updated version in [`setup.py`](../../setup.py)
- [x] Updated version in [`redata/__init__.py`](../../redata/__init__.py)
- [x] Updated version in ReadTheDocs [`conf.py`](../../docs/source/conf.py)

**Begin a new release**
:warning: Do not publish the release until this PR is merged :warning:
- [x] Go to the [New Release](../releases/new) page
- [x] In the `Choose a tag` dropdown, enter a new tag name corresponding to the new version. E.g., `v1.0.1`. Then click "Create new tag on publish"
- [x] The `Target` should be the main or master branch.
- [x] Click the `Generate release notes` button. Review the notes for accuracy
- [x] Save the release as Draft.

**Update Documentation in the Branch**
- [x] Copy the generated release notes from the previous step to the top of `CHANGELOG.md`
- [ ] Update `README.md` (if needed)
- [x] [ReadTheDocs files](../../docs/source/). Check and update the appropriate sections in the .rst files as needed

**Release**
- [x] Merge this PR
- [x] Return to [Releases](../releases) and publish the draft release.