### PR TITLE
Chore update redata commons dependencies 2026

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.14"
     - name: Install PyPI dependencies
       run: |
         python -m pip install --user --upgrade setuptools wheel

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'docs only')"
     strategy:
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
+        python_version: ["3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -37,8 +37,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
-    - name: Install setuptools for python 3.12 and 3.13
-      if: matrix.python_version != '3.11'
+    - name: Install setuptools for python
       run: |
        python -m pip install setuptools
        python -m pip install -r requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.14"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx>=8.0.0
-sphinx-rtd-theme==3.0.2
-sphinx-autodoc-typehints==3.2.0
+sphinx>=9.1.0
+sphinx-rtd-theme==3.1.0
+sphinx-autodoc-typehints==3.6.2
 
 # for logger module
-pandas==2.2.3
+pandas==2.3.3
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2022, Arizona Board of Regents'
 author = 'Research Engagement (University of Arizona Libraries)'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.6.0'
+release = 'v0.6.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/redata/__init__.py
+++ b/redata/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 from . import commons

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 # 2021-04: pandas==1.2.3
 # 2022-07: pandas==1.4.3
 # 2025-06: pandas==2.2.3
-pandas==2.2.3
+# 2026-02: pandas==2.3.3
+pandas==2.3.3
 
 # 2021-04: tabulate==0.8.3
 # 2022-07: tabulate==0.8.10
@@ -13,6 +14,7 @@ tabulate==0.9.0
 # 2021-04: requests==2.25.1
 # 2022-07: requests==2.31.0
 # 2025-06: requests==2.32.3
-requests==2.32.3
+# 2026-02: requests==2.32.5
+requests==2.32.5
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,17 @@
 # 2022-07: pandas==1.4.3
 # 2025-06: pandas==2.2.3
 # 2026-02: pandas==2.3.3
-pandas==2.3.3
+pandas>=2.3.3
 
 # 2021-04: tabulate==0.8.3
 # 2022-07: tabulate==0.8.10
 # 2025-06: tabulate==0.9.0
-tabulate==0.9.0
+tabulate>=0.9.0
 
 # 2021-04: requests==2.25.1
 # 2022-07: requests==2.31.0
 # 2025-06: requests==2.32.3
 # 2026-02: requests==2.32.5
-requests==2.32.5
+requests>=2.32.5
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='redata',
-    version='0.6.0',
+    version='0.6.1',
     packages=find_namespace_packages(),
     url='https://github.com/UAL-RE/redata-commons/',
     project_urls={
@@ -21,11 +21,11 @@ setup(
     description='Commons code used by ReDATA software',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    python_requires='>=3.11',
+    python_requires='>=3.14',
     install_requires=requirements,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.14'
     ]
 )


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This PR makes `Python 3.14` the minimum Python requirement and updates the following dependencies
- `requests` to `v2.32.5`
- `pandas` to `v2.3.3`

<!-- Add any linked issue(s) -->
Fixes #51 

*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->
None

*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
None